### PR TITLE
Fix #6, #7, #8

### DIFF
--- a/bumpr/config.py
+++ b/bumpr/config.py
@@ -111,9 +111,13 @@ class Config(ObjectDict):
                 self[hook.key] = False
 
     def override_from_args(self, parsed_args):
-        for arg in 'file', 'vcs', 'verbose', 'dryrun', 'files':
+        for arg in 'file', 'vcs', 'files':
             if arg in parsed_args and getattr(parsed_args, arg) not in (None, [], tuple()):
                 self[arg] = getattr(parsed_args, arg)
+				
+		for arg in 'verbose', 'dryrun':
+			if arg in parsed_args and getattr(parsed_args, arg):
+				self[arg] = True
 
         self.commit = not parsed_args.nocommit  # pylint: disable=W0201
         self.bump_only = parsed_args.bump_only  # pylint: disable=W0201

--- a/bumpr/config.py
+++ b/bumpr/config.py
@@ -114,10 +114,10 @@ class Config(ObjectDict):
         for arg in 'file', 'vcs', 'files':
             if arg in parsed_args and getattr(parsed_args, arg) not in (None, [], tuple()):
                 self[arg] = getattr(parsed_args, arg)
-				
-		for arg in 'verbose', 'dryrun':
-			if arg in parsed_args and getattr(parsed_args, arg):
-				self[arg] = True
+                
+        for arg in 'verbose', 'dryrun':
+            if arg in parsed_args and getattr(parsed_args, arg):
+                self[arg] = True
 
         self.commit = not parsed_args.nocommit  # pylint: disable=W0201
         self.bump_only = parsed_args.bump_only  # pylint: disable=W0201

--- a/bumpr/hooks.py
+++ b/bumpr/hooks.py
@@ -9,7 +9,7 @@ from os.path import exists
 from bumpr.helpers import execute, BumprError
 
 if sys.version_info < (3, 0):
-	from io import open
+    from io import open
 
 logger = logging.getLogger(__name__)
 

--- a/bumpr/hooks.py
+++ b/bumpr/hooks.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
 
-import codecs
 import logging
+import sys
 
 from os.path import exists
 
 from bumpr.helpers import execute, BumprError
+
+if sys.version_info < (3, 0):
+	from io import open
 
 logger = logging.getLogger(__name__)
 
@@ -88,14 +91,14 @@ class ChangelogHook(Hook):
             raise BumprError('Changelog file does not exists')
 
     def bump(self, replacements):
-        with codecs.open(self.config.file, 'r', self.releaser.config.encoding) as changelog_file:
+        with open(self.config.file, 'r', encoding=self.releaser.config.encoding) as changelog_file:
             before = changelog_file.read()
             after = before.replace(self.dev_header(), self.bumped_header())
         self.releaser.perform(self.config.file, before, after)
 
     def prepare(self, replacements):
         next_header = '\n'.join((self.dev_header(), '', '- {0}'.format(self.config.empty), '', self.bumped_header()))
-        with codecs.open(self.config.file, 'r', self.releaser.config.encoding) as changelog_file:
+        with open(self.config.file, 'r', encoding=self.releaser.config.encoding) as changelog_file:
             before = changelog_file.read()
             after = before.replace(self.bumped_header(), next_header)
         self.releaser.perform(self.config.file, before, after)

--- a/bumpr/releaser.py
+++ b/bumpr/releaser.py
@@ -136,6 +136,8 @@ class Releaser(object):
             self.execute(self.config.clean)
 
     def perform(self, filename, before, after):
+		if before == after:
+			return
         if self.config.dryrun:
             diff = unified_diff(before.split('\n'), after.split('\n'), lineterm='')
             self.diffs[filename] = diff

--- a/bumpr/releaser.py
+++ b/bumpr/releaser.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
 
-import codecs
 import logging
 import re
+import sys
+
+if sys.version_info < (3, 0):
+	from io import open
 
 from datetime import datetime
 from difflib import unified_diff
@@ -137,12 +140,12 @@ class Releaser(object):
             diff = unified_diff(before.split('\n'), after.split('\n'), lineterm='')
             self.diffs[filename] = diff
         else:
-            with open(filename, 'wb') as f:
-                f.write(after.encode(self.config.encoding))
+            with open(filename, 'w', encoding=self.config.encoding) as f:
+                f.write(after)
 
     def bump_files(self, replacements):
         for filename in [self.config.file] + self.config.files:
-            with codecs.open(filename, 'r', self.config.encoding) as current_file:
+            with open(filename, 'r', encoding=self.config.encoding) as current_file:
                 before = current_file.read()
             after = before
             for token, replacement in replacements:

--- a/bumpr/releaser.py
+++ b/bumpr/releaser.py
@@ -6,7 +6,7 @@ import re
 import sys
 
 if sys.version_info < (3, 0):
-	from io import open
+    from io import open
 
 from datetime import datetime
 from difflib import unified_diff
@@ -105,9 +105,9 @@ class Releaser(object):
             self.diffs.clear()
 
     def prepare(self):
-		if self.version == self.next_version:
-			logger.info('Skip prepare phase')
-			return
+        if self.version == self.next_version:
+            logger.info('Skip prepare phase')
+            return
         logger.info('Prepare version %s', self.next_version)
 
         replacements = [
@@ -136,8 +136,8 @@ class Releaser(object):
             self.execute(self.config.clean)
 
     def perform(self, filename, before, after):
-		if before == after:
-			return
+        if before == after:
+            return
         if self.config.dryrun:
             diff = unified_diff(before.split('\n'), after.split('\n'), lineterm='')
             self.diffs[filename] = diff

--- a/bumpr/releaser.py
+++ b/bumpr/releaser.py
@@ -102,6 +102,9 @@ class Releaser(object):
             self.diffs.clear()
 
     def prepare(self):
+		if self.version == self.next_version:
+			logger.info('Skip prepare phase')
+			return
         logger.info('Prepare version %s', self.next_version)
 
         replacements = [

--- a/bumpr/version.py
+++ b/bumpr/version.py
@@ -53,6 +53,10 @@ class Version(object):
     def __repr__(self):
         return "'Version({major},{minor},{patch},{suffix})'".format(**self.__dict__)
 
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            return False
+        return self.__dict__ == other.__dict__
 
 PARTS = {
     'major': Version.MAJOR,


### PR DESCRIPTION


Changes:

* Make `Version` object comparable. Add `.__eq__`.
* Skip prepare phase if the version number isn't changed. This should fix #8.
* Do not write file if the content isn't changed.
* Replace `codecs.open` with `io.open` in python2, or built-in `open` in python3. This should fix #6.
* Make `verbose` and `dryrun` arguments override config file only if it is True. This should fix #7.