### PR TITLE
Fix small issue in config.py

### DIFF
--- a/bumpr/config.py
+++ b/bumpr/config.py
@@ -165,7 +165,7 @@ class Config(ObjectDict):
 
         if hasattr(parsed_args, 'nocommit'):
             self.commit = not parsed_args.nocommit
-        for attr in 'bump_only' 'prepare_only', 'push', 'skip_tests':
+        for attr in 'bump_only', 'prepare_only', 'push', 'skip_tests':
             if hasattr(parsed_args, attr):
                 self[attr] = getattr(parsed_args, attr)
 


### PR DESCRIPTION
Add a comma to separate strings in a 'for' in override_from_args